### PR TITLE
Fixed llList2Json modifying the original variable

### DIFF
--- a/lummao/vendor/lslopt/lsljson.py
+++ b/lummao/vendor/lslopt/lsljson.py
@@ -676,8 +676,7 @@ def llList2Json(kind, lst):
         ret = u'['
         if lst:
             ret += InternalElement2Json(lst[0], ParseNumbers=False)
-            del lst[0]
-            for elem in lst:
+            for elem in lst[1:]:
                 ret += u',' + InternalElement2Json(elem, ParseNumbers=False)
         ret += u']'
 


### PR DESCRIPTION
Using llList2Json with ARRAY serialization would modify the given list, resulting in the first element of the array being deleted each call.